### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- Migrates Renovate from the deprecated `config:base` preset to `config:recommended`.
- Keeps the existing `prConcurrentLimit` unchanged.

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

I did not run `atmos test run` because this repository's `AGENTS.md` says the Terratest suite deploys/destroys real AWS resources and may incur AWS costs. This PR is limited to Renovate configuration only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use the recommended preset for improved dependency update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->